### PR TITLE
Adding content_type and trying to only build on py3.6 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,5 @@ deploy:
   on:
     tags: true
     repo: PaulSchweizer/flowpipe
+    branch: master
+    python: '3.6'

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,12 @@ with open("README.md") as stream:
     long_description = stream.read()
 
 setup(name='flowpipe',
-      version='0.4.5',
+      version='0.4.6',
       author='Paul Schweizer',
       author_email='paulschweizer@gmx.net',
       description='Lightweight flow-based programming framework.',
       long_description=long_description,
+      long_description_content_type='text/markdown',
       url='https://github.com/PaulSchweizer/flowpipe',
       packages=find_packages(),
       classifiers=[


### PR DESCRIPTION
1. Build only on Py3.6 with travis:
https://stackoverflow.com/questions/32892122/prevent-travis-deploying-multiple-times-when-im-running-my-tests-on-multiple-no
2. Pypi github markdown support:
https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi/