### PR TITLE
Added threaded evaluation + rudimentary test

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,3 +6,4 @@ omit =
 exclude_lines =
     except ImportError:
     from ordereddict import OrderedDict
+    pragma: no cover

--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -111,13 +111,10 @@ class Graph(object):
     def evaluate(self, threaded=False, submission_delay=0.1):
         """Evaluate all Nodes.
 
-        Paramters
-        ---------
-        threaded : bool
-            Whether to execute each node in a separate thread.
-        submission_delay : float
-            The delay in seconds between loops issuing new threads if nodes are
-            ready to process.
+        Args:
+            threaded (bool): Whether to execute each node in a separate thread.
+            submission_delay (float): The delay in seconds between loops
+                issuing new threads if nodes are ready to process.
 
         """
         LogObserver.push_message("Evaluating Graph '{0}'".format(self.name))

--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -146,7 +146,7 @@ class Graph(object):
             if len(graph_threads) == 0:
                 # No more threads running after a round of submissions means
                 # we're either done or stuck
-                if not all(not n.is_dirty for n in nodes):
+                if not all(not n.is_dirty for n in nodes):  # pragma: no cover
                     raise RuntimeError(
                         "Could not sucessfully compute all nodes in the graph "
                         "{0}".format(self.name))

--- a/flowpipe/node.py
+++ b/flowpipe/node.py
@@ -45,7 +45,8 @@ class INode(object):
         self.omit = False
         try:
             self.file_location = inspect.getfile(self.__class__)
-        except TypeError as e:
+        except TypeError as e:  # pragma: no cover
+            # Excluded from tests, as this is a hard-to test fringe case
             if str(e) == "<module '__main__'> is a built-in class":
                 warnings.warn("Cannot serialize nodes defined in '__main__'")
                 self.file_location = None
@@ -158,7 +159,7 @@ class INode(object):
 
     def serialize(self):
         """Serialize the node to json."""
-        if self.file_location is None:
+        if self.file_location is None:  # pragma: no cover
             raise RuntimeError("Cannot serialize a node that was not defined "
                                "in a file")
         inputs = OrderedDict()

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 
 import pytest
 
+import time
+
 from flowpipe.node import INode, Node
 from flowpipe.plug import InputPlug, OutputPlug
 from flowpipe.graph import Graph
@@ -334,3 +336,28 @@ def test_nodes_can_add_to_graph_on_init():
         pass
     node = function(graph=graph)
     assert graph["function"] == node
+
+
+def test_threaded_evluation():
+    sleep_time = .3
+    delay = .05
+    graph = Graph(name="threaded")
+
+    @Node(outputs=["out"])
+    def Sleeper(in1):
+        time.sleep(sleep_time)
+
+    s1 = Sleeper(name="Sleeper1", graph=graph)
+    s2 = Sleeper(name="Sleeper2", graph=graph)
+    s3 = Sleeper(name="Sleeper3", graph=graph)
+
+    s1.outputs["out"] >> s2.inputs["in1"]
+    s1.outputs["out"] >> s3.inputs["in1"]
+
+    start = time.time()
+    graph.evaluate(threaded=True, submission_delay=delay)
+    end = time.time()
+
+    runtime = end - start
+    assert 2*sleep_time <= runtime
+    assert runtime <= 2 * sleep_time + 2 * delay

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -339,6 +339,22 @@ def test_nodes_can_add_to_graph_on_init():
 
 
 def test_threaded_evluation():
+    """Test by having sleeper nodes sleep in parallel and check total grah timing.
+
+    +---------------+          +---------------+
+    |   Sleeper1    |          |   Sleeper2    |
+    |---------------|          |---------------|
+    o in1<>         |     +--->o in1<>         |
+    |           out o-----+    |           out o
+    +---------------+     |    +---------------+
+                          |    +---------------+
+                          |    |   Sleeper3    |
+                          |    |---------------|
+                          +--->o in1<>         |
+                               |           out o
+                               +---------------+
+
+    """
     sleep_time = .3
     delay = .05
     graph = Graph(name="threaded")


### PR DESCRIPTION
I extended a suggestion on how to do threaded evaluation by @PaulSchweizer by two minor additions:
1. Names for the threads that follow the scheme `flowpipe.<graph_name>.<node_name>`, which I assume to be safely unique
2. A `submission_delay` parameter in the loop launching the threads. This was added in order to avoid unreasonable resource usage by a loop that does nothing (while all scheduled threads are running). The reasoning is that you would turn to threaded evaluation if your individual nodes take long to process, anyways, and then adding a few tenths of seconds should not matter. It is fully customizable, though, so it can also be set to a millisecond.

The test added is quite rudimentary. I have no prior experience with threading and could not come up with a more thorough test that would not add unnecessary complexity. Thus, I just check the runtime within narrow boundaries, which is one end-to-end test at least.

On a third note, I added back the standard "pragma: no cover" coverage regex to the covereagerc and used it to exclude the jupyter compatibility exceptions. Again, I could not find a decent way to test this.