### PR TITLE
Added a custom JSONEncoder to allow for non-jsonifiable node values.

### DIFF
--- a/flowpipe/node.py
+++ b/flowpipe/node.py
@@ -21,7 +21,7 @@ import warnings
 from .plug import OutputPlug, InputPlug, SubInputPlug, SubOutputPlug
 from .log_observer import LogObserver
 from .stats_reporter import StatsReporter
-from .utilities import deserialize_node
+from .utilities import deserialize_node, NodeEncoder
 from .graph import get_default_graph
 __all__ = ['INode']
 
@@ -119,7 +119,8 @@ class INode(object):
         LogObserver.push_message(
             'Evaluating {0} -> {1}.compute(**{2})'.format(
                 self.file_location, self.class_name,
-                json.dumps(self._sort_plugs(inputs), indent=2)))
+                json.dumps(self._sort_plugs(inputs), indent=2, cls=NodeEncoder)
+            ))
 
         # Compute and redirect the output to the output plugs
         start_time = time.time()
@@ -149,7 +150,8 @@ class INode(object):
         LogObserver.push_message(
             'Evaluation result for {0} -> {1}: {2}'.format(
                 self.file_location, self.class_name,
-                json.dumps(self._sort_plugs(outputs), indent=2)))
+                json.dumps(self._sort_plugs(outputs), indent=2, cls=NodeEncoder)
+            ))
 
         return outputs
 
@@ -261,7 +263,7 @@ class INode(object):
 
             value = ""
             if in_plug.value is not None:
-                value = json.dumps(in_plug.value)
+                value = json.dumps(in_plug.value, cls=NodeEncoder)
             plug = '{symbol} {dist}{input_}{value}'.format(
                 symbol='%' if in_plug._sub_plugs else 'o',
                 dist=' ' if isinstance(in_plug, SubInputPlug)else '',
@@ -316,7 +318,7 @@ class INode(object):
                 pretty.append('{indent}[i] {name}: {value}'.format(
                     indent='   ' if isinstance(plug, SubInputPlug) else '  ',
                     name=name,
-                    value=json.dumps(plug.value)))
+                    value=json.dumps(plug.value, cls=NodeEncoder)))
         for name, plug in sorted(self.all_outputs().items()):
             if plug._sub_plugs:
                 pretty.append('  [o] {name}'.format(name=name))
@@ -332,7 +334,7 @@ class INode(object):
                 pretty.append('{indent}[o] {name}: {value}'.format(
                     indent='   ' if isinstance(plug, SubOutputPlug) else '  ',
                     name=name,
-                    value=json.dumps(plug.value)))
+                    value=json.dumps(plug.value, cls=NodeEncoder)))
 
         return '\n'.join(pretty)
 

--- a/flowpipe/utilities.py
+++ b/flowpipe/utilities.py
@@ -63,9 +63,12 @@ class NodeEncoder(JSONEncoder):
     encoded instead.
     """
 
-    def default(self, obj):
+    def default(self, o):
         """Encode the object, handling type errors by encoding into sha256."""
         try:
-            return super(NodeEncoder, self).default(obj)
+            return super(NodeEncoder, self).default(o)
         except TypeError:
-            return sha256(bytes(obj)).hexdigest()
+            try:
+                return sha256(bytes(o)).hexdigest()
+            except TypeError:
+                return str(o)

--- a/flowpipe/utilities.py
+++ b/flowpipe/utilities.py
@@ -66,6 +66,6 @@ class NodeEncoder(JSONEncoder):
     def default(self, obj):
         """Encode the object, handling type errors by encoding into sha256."""
         try:
-            return JSONEncoder.default(self, obj)
+            return super(NodeEncoder, self).default(self, obj)
         except TypeError:
             return sha256(bytes(obj)).hexdigest()

--- a/flowpipe/utilities.py
+++ b/flowpipe/utilities.py
@@ -69,6 +69,6 @@ class NodeEncoder(JSONEncoder):
             return super(NodeEncoder, self).default(o)
         except TypeError:
             try:
-                return sha256(bytes(o)).hexdigest()
+                return sha256(o).hexdigest()
             except TypeError:
                 return str(o)

--- a/flowpipe/utilities.py
+++ b/flowpipe/utilities.py
@@ -66,6 +66,6 @@ class NodeEncoder(JSONEncoder):
     def default(self, obj):
         """Encode the object, handling type errors by encoding into sha256."""
         try:
-            return super(NodeEncoder, self).default(self, obj)
+            return super(NodeEncoder, self).default(obj)
         except TypeError:
             return sha256(bytes(obj)).hexdigest()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,23 @@
+from __future__ import print_function
+
+import pytest
+
+import json
+from hashlib import sha256
+
+import flowpipe.utilities as util
+
+
+def test_node_encoder():
+    """Test the custom JSONEncoder."""
+    valid_object = {"key": "value", "other_key": [1, 2, 3]}
+    expected_json = '{"key": "value", "other_key": [1, 2, 3]}'
+    json_string = json.dumps(valid_object)
+    assert json_string == expected_json
+
+    invalid_object = {"key": "value", "other_key": bytes(42)}
+    with pytest.raises(TypeError):
+        json.dumps(invalid_object)
+    json_string = json.dumps(invalid_object, cls=util.NodeEncoder)
+    expected_json = '{"key": "value", "other_key": "094c4931fdb2f2af417c9e0322a9716006e8211fe9017f671ac6e3251300acca"}'
+    assert json_string == expected_json

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -34,5 +34,7 @@ def test_node_encoder():
     json_string = json.dumps(weird_object, cls=util.NodeEncoder)
     recovered_json = json.loads(json_string)
     for k, v in weird_object.items():
+        print(k)
+        print(str(recovered_json[k]))
         assert v == recovered_json[k] \
             or re.search('WeirdObject object at', str(recovered_json[k]))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -8,6 +8,12 @@ from hashlib import sha256
 import flowpipe.utilities as util
 
 
+class WeirdObject(object):
+    """An object that is not json serializable and has no bytes() interface."""
+
+    foo = "bar"
+
+
 def test_node_encoder():
     """Test the custom JSONEncoder."""
     valid_object = {"key": "value", "other_key": [1, 2, 3]}
@@ -16,8 +22,16 @@ def test_node_encoder():
     for k, v in valid_object.items():
         assert v == recovered_json[k]
 
-    invalid_object = {"key": "value", "other_key": bytes(42)}
-    json_string = json.dumps(invalid_object, cls=util.NodeEncoder)
+    bytes_object = {"key": "value", "other_key": bytes(42)}
+    json_string = json.dumps(bytes_object, cls=util.NodeEncoder)
     recovered_json = json.loads(json_string)
-    for k, v in invalid_object.items():
-        assert v == recovered_json[k] or sha256(v).hexdigest() == recovered_json[k]
+    for k, v in bytes_object.items():
+        assert v == recovered_json[k] \
+            or sha256(v).hexdigest() == recovered_json[k]
+
+    weird_object = {"key": "value", "other_key": WeirdObject()}
+    json_string = json.dumps(weird_object, cls=util.NodeEncoder)
+    recovered_json = json.loads(json_string)
+    for k, v in bytes_object.items():
+        assert v == recovered_json[k] \
+            or 'WeirdObject object at' in recovered_json[k]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -17,8 +17,6 @@ def test_node_encoder():
         assert v == recovered_json[k]
 
     invalid_object = {"key": "value", "other_key": bytes(42)}
-    with pytest.raises(TypeError):
-        json.dumps(invalid_object)
     json_string = json.dumps(invalid_object, cls=util.NodeEncoder)
     recovered_json = json.loads(json_string)
     for k, v in invalid_object.items():

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -34,15 +34,6 @@ def test_node_encoder():
     json_string = json.dumps(weird_object, cls=util.NodeEncoder)
     recovered_json = json.loads(json_string)
     for k, v in weird_object.items():
-        print(k)
-        print(v)
-        try:
-            print(sha256(v).hexdigest())
-        except:
-            print("Cannot compute sha")
-        print(str(v))
-        print(recovered_json[k])
-        print(str(recovered_json[k]))
         assert v == recovered_json[k] \
             or re.search('WeirdObject object at', str(recovered_json[k])) \
             or sha256(v).hexdigest() == recovered_json[k]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -11,13 +11,15 @@ import flowpipe.utilities as util
 def test_node_encoder():
     """Test the custom JSONEncoder."""
     valid_object = {"key": "value", "other_key": [1, 2, 3]}
-    expected_json = '{"key": "value", "other_key": [1, 2, 3]}'
     json_string = json.dumps(valid_object)
-    assert json_string == expected_json
+    recovered_json = json.loads(json_string)
+    for k, v in valid_object.items():
+        assert v == recovered_json[k]
 
     invalid_object = {"key": "value", "other_key": bytes(42)}
     with pytest.raises(TypeError):
         json.dumps(invalid_object)
     json_string = json.dumps(invalid_object, cls=util.NodeEncoder)
-    expected_json = '{"key": "value", "other_key": "094c4931fdb2f2af417c9e0322a9716006e8211fe9017f671ac6e3251300acca"}'
-    assert json_string == expected_json
+    recovered_json = json.loads(json_string)
+    for k, v in invalid_object.items():
+        assert v == recovered_json[k] or sha256(v).hexdigest() == recovered_json[k]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -34,7 +34,6 @@ def test_node_encoder():
     json_string = json.dumps(weird_object, cls=util.NodeEncoder)
     recovered_json = json.loads(json_string)
     for k, v in weird_object.items():
-        print(k)
-        print(str(recovered_json[k]))
         assert v == recovered_json[k] \
-            or re.search('WeirdObject object at', str(recovered_json[k]))
+            or re.search('WeirdObject object at', str(recovered_json[k])) \
+            or sha256(v).hexdigest() == recovered_json[k]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -36,7 +36,10 @@ def test_node_encoder():
     for k, v in weird_object.items():
         print(k)
         print(v)
-        print(sha256(v).hexdigest())
+        try:
+            print(sha256(v).hexdigest())
+        except:
+            print("Cannot compute sha")
         print(str(v))
         print(recovered_json[k])
         print(str(recovered_json[k]))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -32,6 +32,6 @@ def test_node_encoder():
     weird_object = {"key": "value", "other_key": WeirdObject()}
     json_string = json.dumps(weird_object, cls=util.NodeEncoder)
     recovered_json = json.loads(json_string)
-    for k, v in bytes_object.items():
+    for k, v in weird_object.items():
         assert v == recovered_json[k] \
             or 'WeirdObject object at' in recovered_json[k]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import pytest
 
 import json
+import re
 from hashlib import sha256
 
 import flowpipe.utilities as util
@@ -33,7 +34,5 @@ def test_node_encoder():
     json_string = json.dumps(weird_object, cls=util.NodeEncoder)
     recovered_json = json.loads(json_string)
     for k, v in weird_object.items():
-        print(k)
-        print(v)
         assert v == recovered_json[k] \
-            or 'WeirdObject object at' in recovered_json[k]
+            or re.search('WeirdObject object at', str(recovered_json[k]))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -33,5 +33,7 @@ def test_node_encoder():
     json_string = json.dumps(weird_object, cls=util.NodeEncoder)
     recovered_json = json.loads(json_string)
     for k, v in weird_object.items():
+        print(k)
+        print(v)
         assert v == recovered_json[k] \
             or 'WeirdObject object at' in recovered_json[k]

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -34,6 +34,12 @@ def test_node_encoder():
     json_string = json.dumps(weird_object, cls=util.NodeEncoder)
     recovered_json = json.loads(json_string)
     for k, v in weird_object.items():
+        print(k)
+        print(v)
+        print(sha256(v).hexdigest())
+        print(str(v))
+        print(recovered_json[k])
+        print(str(recovered_json[k]))
         assert v == recovered_json[k] \
             or re.search('WeirdObject object at', str(recovered_json[k])) \
             or sha256(v).hexdigest() == recovered_json[k]


### PR DESCRIPTION
I added a custom JSONEncoder because I work with object that are not json serializable (numpy arrays and custom classes). Since the json encodings we use for logging and string representation break out immediately, I replaced them with sha256 hashes. They still guarantee that you can tell if the same object passed through a plug, while being available for practically everything that can be converted to bytes.

If you see any other use for the custom encoder, do tell me. And of course, if you see this breaking some other part, do tell me as well.