### PR TITLE
Added fix for ValueErrors in the NodeEncoder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
 - '2.7'
-- '3.4'
-- '3.5'
 - '3.6'
 install:
 - pip install -r requirements.txt

--- a/flowpipe/utilities.py
+++ b/flowpipe/utilities.py
@@ -72,3 +72,5 @@ class NodeEncoder(JSONEncoder):
                 return sha256(o).hexdigest()
             except TypeError:
                 return str(o)
+            except ValueError:
+                return sha256(bytes(o)).hexdigest()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ mock
 coverage
 codacy-coverage
 doxypypy
+numpy

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -6,6 +6,8 @@ import json
 import re
 from hashlib import sha256
 
+import numpy as np
+
 import flowpipe.utilities as util
 
 
@@ -37,3 +39,10 @@ def test_node_encoder():
         assert v == recovered_json[k] \
             or re.search('WeirdObject object at', str(recovered_json[k])) \
             or sha256(v).hexdigest() == recovered_json[k]
+
+    weird_np_array = {"key": "value", "other_key": np.arange(10)[::2]}
+    json_string = json.dumps(weird_np_array, cls=util.NodeEncoder)
+    recovered_json = json.loads(json_string)
+    for k, v in weird_np_array.items():
+        assert v == recovered_json[k]\
+            or sha256(bytes(v)).hexdigest() == recovered_json[k]


### PR DESCRIPTION
I added another edge case handling routine to the NodeEncoder. When facing a `ValueError`, we resort to encode the explicit byte representation of the object in question. This will alleviate issues with numpy arrays without creating any additional dependencies and should handle a lot more types.