### PR TITLE
Improve evaluate

### DIFF
--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -190,7 +190,7 @@ class Graph(object):
                 else:
                     empty_loops += 1
             else:
-                empty_loop = 0
+                empty_loops = 0
 
             if not nodes_to_evaluate:
                 break

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -416,6 +416,12 @@ def test_threaded_evaluation():
     assert n3.outputs['result'].value == 3
 
 
+def test_valid_evaluation_mode():
+    eval_modes = ["linear", "threading", "multiprocessing"]
+    for mode in eval_modes:
+        Graph().evaluate(mode=mode)
+
+
 def test_invalid_evaluation_mode():
     with pytest.raises(ValueError):
         Graph().evaluate(mode="foo")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -406,7 +406,7 @@ def test_threaded_evaluation():
     n1.outputs['result'] >> n3.inputs['number1']
 
     start = time.time()
-    graph.evaluate(threaded=True, submission_delay=delay)
+    graph.evaluate(mode="threading", submission_delay=delay)
     end = time.time()
 
     runtime = end - start

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -414,3 +414,8 @@ def test_threaded_evaluation():
     assert runtime < len(graph.nodes) * sleep_time + len(graph.nodes) * delay
     assert n2.outputs['result'].value == 3
     assert n3.outputs['result'].value == 3
+
+
+def test_invalid_evaluation_mode():
+    with pytest.raises(ValueError):
+        Graph().evaluate(mode="foo")

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -48,7 +48,7 @@ def test_multiprocessed_evaluation_is_faster():
     s1.outputs['out'] >> s4.inputs['in1']
 
     start = time.time()
-    graph.evaluate_multiprocessed()
+    graph.evaluate(mode="multiprocessing")
     end = time.time()
 
     runtime = end - start
@@ -121,7 +121,7 @@ def test_multiprocessing_evaluation_updates_the_original_graph():
 
     n4.outputs['results'] >> n5.inputs['numbers']
 
-    graph.evaluate_multiprocessed()
+    graph.evaluate(mode="multiprocessing")
 
     assert n2.outputs['result'].value == 3
     assert n3.outputs['result'].value == 3

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -121,7 +121,7 @@ def test_multiprocessing_evaluation_updates_the_original_graph():
 
     n4.outputs['results'] >> n5.inputs['numbers']
 
-    graph.evaluate(mode="multiprocessing")
+    graph.evaluate(mode="multiprocessing", submission_delay=0)
 
     assert n2.outputs['result'].value == 3
     assert n3.outputs['result'].value == 3


### PR DESCRIPTION
I tried to be as clear as possible while staying concise in the docstring for `Graph.evaluate`. Please take a close look if it makes sense for somebody other than me.

A change I want to highlight for your consideration is that I changed the position at which a node gets dropped from the `nodes_to_evaluate` list in `Graph._evaluate_threaded()`: I now drop the node right after issuing the thread. This allows me to get rid of the extra loop over all nodes and checking whether they are clean to drop them.

I uncovered a bug (?)/unexpected behavior in a test, cf. 
https://github.com/PaulSchweizer/flowpipe/issues/85