### PR TITLE
world_clock.py should use UTC time base, not local time.

### DIFF
--- a/examples/world_clock.py
+++ b/examples/world_clock.py
@@ -24,8 +24,7 @@ A graph implementation of a world clock for demonstrational purposes:
                               |      converted_time o-----+
                               +---------------------+
 """
-from datetime import datetime
-from time import time
+import datetime
 
 from flowpipe import Graph, INode, Node, InputPlug, OutputPlug
 
@@ -37,7 +36,8 @@ def CurrentTime():
     Any arguments to the function are used as input plugs to the Node.
     The outputs are defined in the decorator explicitely.
     """
-    return {'time': time()}
+    utc_now = datetime.datetime.utcnow()
+    return {'time': utc_now}
 
 
 class ConvertTime(INode):
@@ -55,7 +55,7 @@ class ConvertTime(INode):
 
     def compute(self, time, timezone):
         return {
-            'converted_time': time + timezone * 60 * 60
+            'converted_time': time + datetime.timedelta(hours=timezone)
         }
 
 
@@ -64,8 +64,8 @@ def ShowTimes(times):
     """Nodes do not necessarily have to define output and input plugs."""
     print('-- World Clock -------------------')
     for location, t in times.items():
-        print('It is now: {time:%H:%M} in {location}'.format(
-            time=datetime.fromtimestamp(t), location=location))
+        print('It is now: {time} in {location}'.format(
+            time=t.strftime("%Y-%m-%d %H:%M:%S"), location=location))
     print('----------------------------------')
 
 


### PR DESCRIPTION
The example program world_clock.py was reporting incorrect times.  On many/most computers `time.time()` is local time.  Changed it to use UTC as the base time instead.