### PR TITLE
Feature/multithreading revamp

### DIFF
--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -237,7 +237,8 @@ class Graph(object):
         eval_modes = {
             "linear": (self._evaluate_linear, {}),
             "threading": (self._evaluate_threaded, {"max_workers": max_workers}),
-            "multiprocessing": (self._evaluate_multiprocessed, {"submission_delay": submission_delay})
+            "multiprocessing": (self._evaluate_multiprocessed,
+                                {"submission_delay": submission_delay})
         }
 
         try:
@@ -257,13 +258,15 @@ class Graph(object):
 
     def _evaluate_linear(self, nodes_to_evaluate):
         """Iterate over all nodes in a single thread (the current one)."""
-        log.debug("Evaluating {0} nodes in linear mode.".format(len(nodes_to_evaluate)))
+        log.debug("{0} evaluating {1} nodes in linear mode.".format(
+            self.name, len(nodes_to_evaluate)))
         for node in nodes_to_evaluate:
             node.evaluate()
 
     def _evaluate_threaded(self, nodes_to_evaluate, max_workers=None):
         """Evaluate each node in a new thread."""
-        log.debug("Evaluating {0} nodes in threading mode.".format(len(nodes_to_evaluate)))
+        log.debug("{0} evaluating {1} nodes in threading mode.".format(
+            self.name, len(nodes_to_evaluate)))
         def node_runner(node):
             """Run a node's evaluate method and return the node."""
             node.evaluate()
@@ -297,7 +300,8 @@ class Graph(object):
         The original node objects are updated with the results from the
         corresponding processes to reflect the evaluation.
         """
-        log.debug("Evaluating {0} nodes in multiprocessing mode.".format(len(nodes_to_evaluate)))
+        log.debug("{0} evaluating {1} nodes in multiprocessing mode.".format(
+            self.name, len(nodes_to_evaluate)))
         manager = Manager()
         nodes_data = manager.dict()
         processes = {}

--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -244,12 +244,9 @@ class Graph(object):
         try:
             eval_func, eval_func_args = eval_modes[mode]
         except KeyError:
-            mode_options = ""
-            for m in eval_modes:
-                mode_options += m + " "
-            mode_options = mode_options[:-1]  # get rid of trailing space
-            raise ValueError("Invalid mode {0}, options are {1}".format(
-                mode, mode_options))
+            mode_options = ", ".join(eval_modes.keys())
+            raise ValueError(
+                "Invalid mode {0}, options are {1}".format(mode, mode_options))
 
         nodes_to_evaluate = [n for n in self.evaluation_sequence
                              if n.is_dirty or not skip_clean]

--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -279,7 +279,7 @@ class Graph(object):
 
         running_futures = []
         with futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
-            while True:
+            while nodes_to_evaluate:
                 # Submit new nodes that are ready to be evaluated
                 for node in nodes_to_evaluate:
                     if not any(n.is_dirty for n in node.upstream_nodes):
@@ -296,9 +296,6 @@ class Graph(object):
                         nodes_to_evaluate.remove(s.result())
                     except ValueError: #  The node is not in the list anyways
                         pass
-
-                if not nodes_to_evaluate:
-                    break
 
     def _evaluate_multiprocessed(self, skip_clean, submission_delay, **kwargs):
         """Similar to the threaded evaluation but with multiprocessing.

--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -273,6 +273,7 @@ class Graph(object):
                              if n.is_dirty or not skip_clean]
 
         def node_runner(node):
+            """Run a node's evaluate method and return the node."""
             node.evaluate()
             return node
 

--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -256,16 +256,14 @@ class Graph(object):
         eval_func(nodes_to_evaluate, **eval_func_args)
 
     def _evaluate_linear(self, nodes_to_evaluate):
-        """Iterate over all nodes in a single thread (the current one).
-
-        Args:
-            kwargs: included to allow for the factory pattern for eval modes
-        """
+        """Iterate over all nodes in a single thread (the current one)."""
+        log.debug("Evaluating {0} nodes in linear mode.".format(len(nodes_to_evaluate)))
         for node in nodes_to_evaluate:
             node.evaluate()
 
     def _evaluate_threaded(self, nodes_to_evaluate, max_workers=None):
         """Evaluate each node in a new thread."""
+        log.debug("Evaluating {0} nodes in threading mode.".format(len(nodes_to_evaluate)))
         def node_runner(node):
             """Run a node's evaluate method and return the node."""
             node.evaluate()
@@ -299,6 +297,7 @@ class Graph(object):
         The original node objects are updated with the results from the
         corresponding processes to reflect the evaluation.
         """
+        log.debug("Evaluating {0} nodes in multiprocessing mode.".format(len(nodes_to_evaluate)))
         manager = Manager()
         nodes_data = manager.dict()
         processes = {}

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ with open('README.md') as stream:
 REQUIREMENTS = [
     'ascii-canvas>=1.2.2',
     'ordereddict>=1.1',
-    'strip-hints>=0.1.7'
+    'strip-hints>=0.1.7',
+    'futures; python_version == "2.7"'
 ]
 
 setup(name='flowpipe',


### PR DESCRIPTION
I revamped the threaded evaluation and employ the ThreadPoolExecutor from python's concurrent.futures module. This module was added in python3, but a backport for python2 is available on PYPI as "futures" package.

The ThreadPoolExecutor has a few key advantages over manual Thread management:
* It makes sure all threads are cleaned up, even if a exception breaks the loop
* It allows to set a maximum number of threads (useful for very wide graphs)
* It raises exceptions that happen in threads spawned by it with a useful stacktrace.

I have not yet added the futures package to the requirements.txt, since it might break python3 installations. The recommended method (cf. https://pypi.org/project/futures/) to add it to a project is by adding it to the setup.py installation requirements for python2. 

This PR closes https://github.com/PaulSchweizer/flowpipe/issues/112 as the situation in question can no longer occur and exceptions in threads are handled pythonically.