### PR TITLE
Add logo to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Codacy_Badge_Coverage](https://api.codacy.com/project/badge/Coverage/6ac650d8580d43dbaf7de96a3171e76f)](https://www.codacy.com/app/paulschweizer/flowpipe?utm_source=github.com&utm_medium=referral&utm_content=PaulSchweizer/flowpipe&utm_campaign=Badge_Coverage) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![python 2.7](https://img.shields.io/badge/python-2.7%2B-blue.svg)](https://www.python.org/downloads/) [![python 3.6+](https://img.shields.io/badge/python-3.6%2B-blue.svg)](https://www.python.org/downloads/)
 
 
+[LOGO](logo.png)
 # Flow-based Programming
 A lightweight framework for flow-based programming in python.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codacy_Badge_Coverage](https://api.codacy.com/project/badge/Coverage/6ac650d8580d43dbaf7de96a3171e76f)](https://www.codacy.com/app/paulschweizer/flowpipe?utm_source=github.com&utm_medium=referral&utm_content=PaulSchweizer/flowpipe&utm_campaign=Badge_Coverage) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![python 2.7](https://img.shields.io/badge/python-2.7%2B-blue.svg)](https://www.python.org/downloads/) [![python 3.6+](https://img.shields.io/badge/python-3.6%2B-blue.svg)](https://www.python.org/downloads/)
 
 
-[LOGO](logo.png)
+[LOGO](logo.png?raw=true)
 # Flow-based Programming
 A lightweight framework for flow-based programming in python.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Codacy_Badge_Coverage](https://api.codacy.com/project/badge/Coverage/6ac650d8580d43dbaf7de96a3171e76f)](https://www.codacy.com/app/paulschweizer/flowpipe?utm_source=github.com&utm_medium=referral&utm_content=PaulSchweizer/flowpipe&utm_campaign=Badge_Coverage) [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![python 2.7](https://img.shields.io/badge/python-2.7%2B-blue.svg)](https://www.python.org/downloads/) [![python 3.6+](https://img.shields.io/badge/python-3.6%2B-blue.svg)](https://www.python.org/downloads/)
 
 
-[LOGO](logo.png?raw=true)
+![LOGO](logo.png?raw=true)
 # Flow-based Programming
 A lightweight framework for flow-based programming in python.
 


### PR DESCRIPTION
When I showed the repo to a colleague recently, I mentioned the logo and wondered why we don't include it at the top of the README.md, as many other libraries do.

So, the amazing logo is now on full display in case some user finds flowpipe!