### PR TITLE
Replaced imp with importlib

### DIFF
--- a/flowpipe/utilities.py
+++ b/flowpipe/utilities.py
@@ -2,7 +2,6 @@ try:
     import importlib
 except ImportError:
     pass
-import imp
 import json
 from hashlib import sha256
 import sys
@@ -22,7 +21,10 @@ def import_class(module, cls_name, file_location=None):
     try:
         cls = getattr(module, cls_name)
     except AttributeError:  # pragma: no cover
-        module = imp.load_source('module', file_location)
+        loader = importlib.machinery.SourceFileLoder('module', file_location)
+        spec = importlib.machinery.ModuleSpec('module', loader,
+                                              origin=file_location)
+        module = importlib.util.module_from_spec(spec)
         cls = getattr(module, cls_name)
     return cls
 


### PR DESCRIPTION
I only found one reference to `imp`, in utilities (I think the appearance of `imp` in `node.py` that is mentioned [here](https://github.com/PaulSchweizer/flowpipe/issues/47) was dropped when we refactored the serialization stuff to `utilities.py`)

I followed [this post from 2014](https://grokbase.com/t/python/python-ideas/14c8cg6vgd/restitute-imp-load-source-or-equivalent-in-python-3) that included a recipe on "how to properly replace imp.load_source with importlib".

Since I don't have any code that actually uses this serialization and the only call to this functionality is in an untested `except` clause, I can't guarantee for this to work. If someone has a piece of code that actually depends on this import funcitonality, it would be great if they could try it out and report issues here.