### PR TITLE
Made EVENTS an instance variable intead of a class variable

### DIFF
--- a/flowpipe/node.py
+++ b/flowpipe/node.py
@@ -27,7 +27,7 @@ log = logging.getLogger(__name__)
 # Use getfullargspec on py3.x to make type hints work
 try:
     getargspec = inspect.getfullargspec
-except AttributeError:
+except AttributeError:  # pragma: no cover
     getargspec = inspect.getargspec
 
 
@@ -36,11 +36,9 @@ class INode(object):
 
     __metaclass__ = ABCMeta
 
-    EVENTS = {
-        'evaluation-omitted': Event('evaluation-omitted'),
-        'evaluation-started': Event('evaluation-started'),
-        'evaluation-finished': Event('evaluation-finished')
-    }
+    EVENT_TYPES = ['evaluation-omitted',
+                   'evaluation-started',
+                   'evaluation-finished']
 
     def __init__(self, name=None, identifier=None, metadata=None,
                  graph='default'):
@@ -52,6 +50,8 @@ class INode(object):
                 If set to 'default', the Node is added to the default graph.
                 If set to None, the Node is not added to any grpah.
         """
+        self.EVENTS = {ev_type: Event(ev_type) for ev_type in self.EVENT_TYPES}
+
         self.name = name if name is not None else self.__class__.__name__
         self.identifier = (identifier if identifier is not None
                            else '{0}-{1}'.format(self.name, uuid.uuid4()))
@@ -125,10 +125,10 @@ class INode(object):
         evaluation time and timestamp the computation started.
         """
         if self.omit:
-            INode.EVENTS['evaluation-omitted'].emit(self)
+            self.EVENTS['evaluation-omitted'].emit(self)
             return {}
 
-        INode.EVENTS['evaluation-started'].emit(self)
+        self.EVENTS['evaluation-started'].emit(self)
 
         inputs = {}
         for name, plug in self.inputs.items():
@@ -156,7 +156,7 @@ class INode(object):
         for input_ in self.all_inputs().values():
             input_.is_dirty = False
 
-        INode.EVENTS['evaluation-finished'].emit(self)
+        self.EVENTS['evaluation-finished'].emit(self)
 
         return outputs
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -406,12 +406,12 @@ def test_threaded_evaluation():
                                |        result o
                                +---------------+
     """
-    sleep_time = 1
-    delay = .05
+    sleep_time = .2
     graph = Graph(name='threaded')
 
     @Node(outputs=['result'])
     def AddNode(number1, number2):
+        time.sleep(sleep_time)
         return {'result': number1 + number2}
 
     n1 = AddNode(name='AddNode1', graph=graph, number1=1, number2=1)
@@ -422,12 +422,12 @@ def test_threaded_evaluation():
     n1.outputs['result'] >> n3.inputs['number1']
 
     start = time.time()
-    graph.evaluate(mode="threading", submission_delay=delay)
+    graph.evaluate(mode="threading", max_workers=2)
     end = time.time()
 
     runtime = end - start
 
-    assert runtime < len(graph.nodes) * sleep_time + len(graph.nodes) * delay
+    assert runtime < len(graph.nodes) * sleep_time
     assert n2.outputs['result'].value == 3
     assert n3.outputs['result'].value == 3
 


### PR DESCRIPTION
When the EVENTS dictionary is a class variable, any INode triggering an event will run the registered listeners for each INode subclass the interpreter knows about. I remedied that by making the EVENTS attribute an instace variable instead of a class variable.

To assert event type consistency on all INodes, the EVENTS dictionary is populated from a list of EVENT_TYPES which still needs to be defined on the INode base class only.