### PR TITLE
Added an Event.clear() method that removes all listeners.

### DIFF
--- a/flowpipe/event.py
+++ b/flowpipe/event.py
@@ -45,3 +45,8 @@ class Event(object):
     def is_registered(self, listener):
         """Whether the given function object is already registered."""
         return listener in self._listeners
+
+    def clear(self):
+        """Remove all listeners from this event."""
+        for l in self._listeners:
+            self.deregister(l)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 pytest==3.0.3
 pytest-cov==2.5.1
 mock

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -34,3 +34,15 @@ def test_event_emitt():
     event = Event("test")
     event.register(listener)
     event.emit(123, kwarg="test")
+
+
+def test_event_clear():
+    def listener(arg, kwarg):
+        pass
+
+    event = Event("test")
+    event.register(listener)
+    event.clear()
+
+    assert not event.is_registered(listener)
+    assert len(event._listeners) == 0


### PR DESCRIPTION
I ran into the situations where it was a hindrance to have listeners registered to events. More concretely, having listeners registered prevented me from using the pickle library to serialize the graph into a binary blob.

Looping over all nodes and events, I was missing a convenience function to deregister all listeners. As of now, I loop over `event._listeners` manually, but accessing the class' internals is not good style.