### PR TITLE
Added deprecation of rshift and lshift operators 

### DIFF
--- a/flowpipe/plug.py
+++ b/flowpipe/plug.py
@@ -181,7 +181,7 @@ class OutputPlug(IPlug):
         Set both participating Plugs dirty.
         """
         if not isinstance(plug, self.accepted_plugs):
-            raise ValueError("Cannot connect {0} to {1}".format(
+            raise TypeError("Cannot connect {0} to {1}".format(
                 type(self), type(plug)))
         if self.node.graph.accepts_connection(self, plug):
             for connection in plug.connections:
@@ -272,7 +272,7 @@ class InputPlug(IPlug):
         Set both participating Plugs dirty.
         """
         if not isinstance(plug, self.accepted_plugs):
-            raise ValueError("Cannot connect {0} to {1}".format(
+            raise TypeError("Cannot connect {0} to {1}".format(
                 type(self), type(plug)))
         if self.node.graph.accepts_connection(plug, self):
             for connection in self.connections:
@@ -340,7 +340,7 @@ class SubInputPlug(IPlug):
         Set both participating Plugs dirty.
         """
         if not isinstance(plug, self.accepted_plugs):
-            raise ValueError("Cannot connect {0} to {1}".format(
+            raise TypeError("Cannot connect {0} to {1}".format(
                 type(self), type(plug)))
         if self.node.graph.accepts_connection(plug, self):
             for connection in self.connections:
@@ -422,7 +422,7 @@ class SubOutputPlug(IPlug):
         Set both participating Plugs dirty.
         """
         if not isinstance(plug, self.accepted_plugs):
-            raise ValueError("Cannot connect {0} to {1}".format(
+            raise TypeError("Cannot connect {0} to {1}".format(
                 type(self), type(plug)))
         if self.node.graph.accepts_connection(self, plug):
             for connection in plug.connections:

--- a/flowpipe/plug.py
+++ b/flowpipe/plug.py
@@ -45,7 +45,8 @@ class IPlug(object):
         Args:
             other (IPlug): The IPlug to connect to.
         """
-        warnings.warn("Use the connect method instead", DeprecationWarning, stacklevel=2)
+        warnings.warn("Use the connect method instead", 
+                      DeprecationWarning, stacklevel=2)
         if isinstance(other, self.accepted_plugs):
             self.connect(other)
 
@@ -55,7 +56,8 @@ class IPlug(object):
         Args:
             other (IPlug): The IPlug to disconnect.
         """
-        warnings.warn("Use the disconnect method instead", DeprecationWarning, stacklevel=2)
+        warnings.warn("Use the disconnect method instead", 
+                      DeprecationWarning, stacklevel=2)
         if isinstance(other, self.accepted_plugs):
             self.disconnect(other)
 

--- a/flowpipe/plug.py
+++ b/flowpipe/plug.py
@@ -269,6 +269,9 @@ class InputPlug(IPlug):
 
         Set both participating Plugs dirty.
         """
+        if not isinstance(plug, self.accepted_plugs):
+            raise ValueError("Cannot connect {0} to {1}".format(
+                type(self), type(plug)))
         if self.node.graph.accepts_connection(plug, self):
             for connection in self.connections:
                 self.disconnect(connection)
@@ -334,6 +337,9 @@ class SubInputPlug(IPlug):
 
         Set both participating Plugs dirty.
         """
+        if not isinstance(plug, self.accepted_plugs):
+            raise ValueError("Cannot connect {0} to {1}".format(
+                type(self), type(plug)))
         if self.node.graph.accepts_connection(plug, self):
             for connection in self.connections:
                 self.disconnect(connection)
@@ -413,6 +419,9 @@ class SubOutputPlug(IPlug):
 
         Set both participating Plugs dirty.
         """
+        if not isinstance(plug, self.accepted_plugs):
+            raise ValueError("Cannot connect {0} to {1}".format(
+                type(self), type(plug)))
         if self.node.graph.accepts_connection(self, plug):
             for connection in plug.connections:
                 plug.disconnect(connection)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -166,9 +166,8 @@ def test_serialize_graph_to_json(clear_default_graph, branching_graph):
 
 def test_serialize_graph_to_pickle(clear_default_graph, branching_graph):
     serialized = branching_graph.to_pickle()
-    deserialized = Graph.from_pickle(serialized).to_pickle()
-
-    assert serialized == deserialized
+    deserialized = Graph.from_pickle(serialized)
+    assert deserialized.to_json() == branching_graph.to_json()
 
 
 def test_string_representations(clear_default_graph, branching_graph):


### PR DESCRIPTION
Added deprecation of rshift and lshift operators where they aren't intuitive;

Changed test for pickle sanity, as in python 3.8 the bytes of the pickle change after the first round trip