### PR TITLE
Feature/automatic connections

### DIFF
--- a/flowpipe/node.py
+++ b/flowpipe/node.py
@@ -63,7 +63,7 @@ class INode(object):
             self.file_location = inspect.getfile(self.__class__)
         except TypeError as e:  # pragma: no cover
             # Excluded from tests, as this is a hard-to test fringe case
-            if str(e) == "<module '__main__'> is a built-in class":
+            if all(s in str(e) for s in ('__main__', 'built-in class')):
                 warnings.warn("Cannot serialize nodes defined in '__main__'")
                 self.file_location = None
             else:

--- a/flowpipe/node.py
+++ b/flowpipe/node.py
@@ -15,7 +15,7 @@ import time
 import uuid
 import warnings
 
-from .plug import OutputPlug, InputPlug, SubInputPlug, SubOutputPlug
+from .plug import _InPlug, OutputPlug, InputPlug, SubInputPlug, SubOutputPlug
 from .event import Event
 from .utilities import deserialize_node, NodeEncoder, import_class
 from .graph import get_default_graph
@@ -161,11 +161,35 @@ class INode(object):
         return outputs
 
     @abstractmethod
-    def compute(self, *args, **kwargs):
+    def compute(self, *args, **kwargs):  # pragma: no cover
         """Implement the data manipulation in the subclass.
 
         Return a dictionary with the outputs from this function.
         """
+        raise NotImplementedError("Compute must be overwritten")
+
+    def __rshift__(self, other):
+        """Syntactic sugar for connecting outputs of this node based on names.
+
+        If other is an _InPlug, connect the output with matching name.
+        If other is an INode, connect all outputs with matching names.
+        """
+        if isinstance(other, _InPlug):
+            try:
+                self.outputs[other.name].connect(other)
+            except KeyError:
+                raise KeyError("No output named {0}".format(other.name))
+        elif isinstance(other, INode):
+            no_connection = True
+            for key in self.outputs.keys():
+                if key in other.inputs:
+                    self.outputs[key].connect(other.inputs[key])
+                    no_connection = False
+            if no_connection:
+                raise ValueError("{0} has no matching inputs".format(
+                    other.name))
+        else:
+            raise TypeError("Cannot connect outputs to {}".format(type(other)))
 
     def on_input_plug_set_dirty(self):
         """Propagate the dirty state to the connected downstream nodes."""

--- a/flowpipe/plug.py
+++ b/flowpipe/plug.py
@@ -181,7 +181,7 @@ class OutputPlug(IPlug):
         Set both participating Plugs dirty.
         """
         if not isinstance(plug, self.accepted_plugs):
-            raise ValueError("Cannot connect {0} to {1}".format(
+            raise TypeError("Cannot connect {0} to {1}".format(
                 type(self), type(plug)))
         if self.node.graph.accepts_connection(self, plug):
             for connection in plug.connections:
@@ -272,7 +272,7 @@ class InputPlug(IPlug):
         Set both participating Plugs dirty.
         """
         if not isinstance(plug, self.accepted_plugs):
-            raise ValueError("Cannot connect {0} to {1}".format(
+            raise TypeError("Cannot connect {0} to {1}".format(
                 type(self), type(plug)))
         if self.node.graph.accepts_connection(plug, self):
             for connection in self.connections:
@@ -340,7 +340,7 @@ class SubInputPlug(IPlug):
         Set both participating Plugs dirty.
         """
         if not isinstance(plug, self.accepted_plugs):
-            raise ValueError("Cannot connect {0} to {1}".format(
+            raise TypeError("Cannot connect {0} to {1}".format(
                 type(self), type(plug)))
         if self.node.graph.accepts_connection(plug, self):
             for connection in self.connections:
@@ -422,7 +422,7 @@ class SubOutputPlug(IPlug):
         Set both participating Plugs dirty.
         """
         if not isinstance(plug, self.accepted_plugs):
-            raise ValueError("Cannot connect {0} to {1}".format(
+            raise TypeError("Cannot connect {0} to {1}".format(
                 type(self), type(plug)))
         if self.node.graph.accepts_connection(self, plug):
             for connection in plug.connections:

--- a/flowpipe/plug.py
+++ b/flowpipe/plug.py
@@ -45,7 +45,8 @@ class IPlug(object):
         Args:
             other (IPlug): The IPlug to connect to.
         """
-        warnings.warn("Use the connect method instead", DeprecationWarning, stacklevel=2)
+        warnings.warn("Use the connect method instead", 
+                      DeprecationWarning, stacklevel=2)
         if isinstance(other, self.accepted_plugs):
             self.connect(other)
 
@@ -55,7 +56,8 @@ class IPlug(object):
         Args:
             other (IPlug): The IPlug to disconnect.
         """
-        warnings.warn("Use the disconnect method instead", DeprecationWarning, stacklevel=2)
+        warnings.warn("Use the disconnect method instead", 
+                      DeprecationWarning, stacklevel=2)
         if isinstance(other, self.accepted_plugs):
             self.disconnect(other)
 

--- a/flowpipe/plug.py
+++ b/flowpipe/plug.py
@@ -126,8 +126,18 @@ class _OutPlug(IPlug):
         super().__init__(name, node)
 
     def __rshift__(self, other):
-        """Syntactic sugar for the connect() method."""
-        self.connect(other)
+        """Syntactic sugar for the connect() method.
+
+        If `other` is a INode with an input matching this plug's name, connect.
+        """
+        # softly check if the "other" is a Node with inputs
+        if hasattr(other, "inputs"):
+            for iname, iplug in other.inputs.items():
+                if iname == self.name:
+                    target = iplug
+        else:
+            target = other
+        self.connect(target)
 
     def connect(self, plug):
         """Connect this Plug to the given InputPlug.

--- a/flowpipe/plug.py
+++ b/flowpipe/plug.py
@@ -269,6 +269,9 @@ class InputPlug(IPlug):
 
         Set both participating Plugs dirty.
         """
+        if not isinstance(plug, self.accepted_plugs):
+            raise ValueError("Cannot connect {0} to {1}".format(
+                type(self), type(plug)))
         if self.node.graph.accepts_connection(plug, self):
             for connection in self.connections:
                 self.disconnect(connection)
@@ -334,6 +337,9 @@ class SubInputPlug(IPlug):
 
         Set both participating Plugs dirty.
         """
+        if not isinstance(plug, self.accepted_plugs):
+            raise ValueError("Cannot connect {0} to {1}".format(
+                type(self), type(plug)))
         if self.node.graph.accepts_connection(plug, self):
             for connection in self.connections:
                 self.disconnect(connection)
@@ -413,6 +419,9 @@ class SubOutputPlug(IPlug):
 
         Set both participating Plugs dirty.
         """
+        if not isinstance(plug, self.accepted_plugs):
+            raise ValueError("Cannot connect {0} to {1}".format(
+                type(self), type(plug)))
         if self.node.graph.accepts_connection(self, plug):
             for connection in plug.connections:
                 plug.disconnect(connection)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -166,9 +166,8 @@ def test_serialize_graph_to_json(clear_default_graph, branching_graph):
 
 def test_serialize_graph_to_pickle(clear_default_graph, branching_graph):
     serialized = branching_graph.to_pickle()
-    deserialized = Graph.from_pickle(serialized).to_pickle()
-
-    assert serialized == deserialized
+    deserialized = Graph.from_pickle(serialized)
+    assert deserialized.to_json() == branching_graph.to_json()
 
 
 def test_string_representations(clear_default_graph, branching_graph):

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -637,3 +637,58 @@ def test_node_event_emission_separation(clear_default_graph):
 
     assert node1.execution_count == 1
     assert node2.execution_count == 1
+
+
+def test_rshift_into_plug(clear_default_graph):
+    """Test the node rshift operator with a plug as target.
+    Note that OutputPlug >> INode is tested in the plug tests."""
+    @Node(outputs=["marker"])
+    def Node1():
+        return {"marker": None}
+
+    @Node(outputs=[])
+    def Node2(marker):
+        return {}
+
+    @Node(outputs=[])
+    def Node3(no_such_input):
+        return {}
+
+    n1 = Node1()
+    n2 = Node2()
+    n3 = Node3()
+
+    n1 >> n2.inputs["marker"]
+    assert n2.inputs["marker"] in n1.outputs["marker"].connections
+
+    with pytest.raises(KeyError):
+        n1 >> n3.inputs["no_such_input"]
+
+    with pytest.raises(TypeError):
+        n1 >> "a string"
+
+
+def test_rshift_into_node(clear_default_graph):
+    """Test the node rshift operator with an INode as target.
+    Note that OutputPlug >> INode is tested in the plug tests."""
+    @Node(outputs=["marker"])
+    def Node1():
+        return {"marker": None}
+
+    @Node(outputs=[])
+    def Node2(marker):
+        return {}
+
+    @Node(outputs=[])
+    def Node3(no_such_input):
+        return {}
+
+    n1 = Node1()
+    n2 = Node2()
+    n3 = Node3()
+
+    n1 >> n2
+    assert n2.inputs["marker"] in n1.outputs["marker"].connections
+
+    with pytest.raises(ValueError):
+        n1 >> n3

--- a/tests/test_plugs.py
+++ b/tests/test_plugs.py
@@ -566,3 +566,23 @@ def test_plug_gets_dirty_only_on_change(clear_default_graph):
     out_plug.value = "baz"
     assert in_plug.is_dirty
     assert out_plug.is_dirty
+
+
+def test_forbidden_connect(clear_default_graph):
+    """Test connections between plugs that are forbidden."""
+    n1 = NodeForTesting(name="n1")
+    in_plug1 = InputPlug('in', n1)
+    out_plug1 = OutputPlug('out', n1)
+
+    n2 = NodeForTesting(name="n2")
+    in_plug2 = InputPlug('in', n2)
+    out_plug2 = OutputPlug('out', n2)
+
+    with pytest.raises(TypeError):
+        out_plug1.connect(out_plug2)
+
+    with pytest.raises(TypeError):
+        in_plug1.connect(in_plug1)
+
+    with pytest.raises(TypeError):
+        out_plug1.connect("a string")

--- a/tests/test_plugs.py
+++ b/tests/test_plugs.py
@@ -586,3 +586,15 @@ def test_forbidden_connect(clear_default_graph):
 
     with pytest.raises(TypeError):
         out_plug1.connect("a string")
+
+
+def test_rshift_into_node(clear_default_graph):
+    """Test the syntactic sugar for rshift operator between plug and node."""
+    n1 = NodeForTesting(name="n1")
+    n2 = NodeForTesting(name="n2")
+    out_plug = OutputPlug('foo', n1)
+    in_plug = InputPlug('foo', n2)
+
+    out_plug >> n2
+
+    assert in_plug in out_plug.connections


### PR DESCRIPTION
In addition to adding the deprecations of `>>` and `<<` as discussed in https://github.com/PaulSchweizer/flowpipe/issues/56 I revamped the way output and input plugs are differentiated:

I made things more DRY by adding new intermediate classes `_InPlug` and `_OutPlug`. I employed the prepending-an-underscore mnemonic to show that these are base classes not intended for independent use. These define the connection abilities of Input and Output plugs, so that the connection code is no longer repeated between e.g. `OutputPlug` and `SubOutputPlug`. Moreover, calling the connect method on an input now refers to the connect method of the target output, to reduce code repetition even more and make things easier to maintain.

I added the new `>>` operator to `_OutPlug` and `INode`. One slight hack I had to resort to is that the check whether the target of `_OutPlug.__rshift__` is an `INode` is soft, i.e. I just could check for the existence of an `inputs` property. since importing the `INode` class directly would yield a cyclic import situation.