### PR TITLE
Made the Graph.__getitem__ descend into subgraphs via Graph.all_nodes

### DIFF
--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -43,7 +43,7 @@ class Graph(object):
 
     def __getitem__(self, key):
         """Grant access to Nodes via their name."""
-        for node in self.nodes:
+        for node in self.all_nodes:
             if node.name == key:
                 return node
         raise KeyError(


### PR DESCRIPTION
Making the `Graph.__getitem__` accesor descend into subgraphs when retrieving nodes.

Closes
https://github.com/PaulSchweizer/flowpipe/issues/143