### PR TITLE
Access nodes on graph by name was ambivalent

### DIFF
--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -1,23 +1,23 @@
 """A Graph of Nodes."""
-from __future__ import print_function
-from __future__ import absolute_import
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
-from concurrent import futures
+from __future__ import absolute_import, print_function
+
 import logging
-from multiprocessing import Manager, Process
 import pickle
 import time
 import warnings
+from concurrent import futures
+from multiprocessing import Manager, Process
 
-from ascii_canvas import canvas
-from ascii_canvas import item
+from ascii_canvas import canvas, item
 
 from .errors import CycleError
 from .plug import InputPlug, OutputPlug
 from .utilities import deserialize_graph
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 
 log = logging.getLogger(__name__)
@@ -43,11 +43,22 @@ class Graph(object):
 
     def __getitem__(self, key):
         """Grant access to Nodes via their name."""
-        for node in self.all_nodes:
+        for node in self.nodes:
             if node.name == key:
                 return node
+        # Search through subgraphs if no node found on graph itself
+        if "." in key:
+            subgraph_name = key.split(".")[0]
+            node_name = key.split(".")[-1]
+            for node in self.all_nodes:
+                if node.name == node_name and node.graph.name == subgraph_name:
+                    return node
+
         raise KeyError(
-            "Graph does not contain a Node named '{0}'".format(key))
+            "Graph does not contain a Node named '{0}'. "
+            "If the node is part of a subgraph of this graph, use this "
+            "form to access the node: '{{subgraph.name}}.{{node.name}}', "
+            "e.g. 'sub.node'".format(key))
 
     @property
     def all_nodes(self):

--- a/tests/test_subgraphs.py
+++ b/tests/test_subgraphs.py
@@ -1,7 +1,5 @@
 import pytest
-
-from flowpipe import Graph
-from flowpipe import Node
+from flowpipe import Graph, Node
 
 
 @Node(outputs=["out"])
@@ -154,3 +152,16 @@ def test_serialize_nested_graph_to_json():
     deserialized = Graph.from_json(serialized).to_json()
 
     assert serialized == deserialized
+
+
+def test_access_node_of_subgraph_by_key():
+    main = Graph("main")
+    main_node = DemoNode(name="node", graph=main)
+
+    sub = Graph("sub")
+    sub_node = DemoNode(name="node", graph=sub)
+
+    main["node"].outputs["out"] >> sub["node"].inputs["in_"]
+
+    assert main["node"] == main_node
+    assert main["sub.node"] == sub_node


### PR DESCRIPTION
#144 caused a problem where it was unclear which node was accessed if nodes on subgraphs had the same name as nodes on the main graph: 

```python
main = Graph("main")
DemoNode(name="node", graph=main)

sub = Graph("sub")
DemoNode(name="node", graph=sub)

main["node"].outputs["out"] >> sub["node"].inputs["in_"]

# Problem: It was unclear which node this is:
main["node"]
```

This PR introduces the following syntax to safely distinguish between the nodes:
```python
main["node"]  # The node on the main graph
main["sub.node"]  # The node with the same name on the sub graph 
```
