### PR TITLE
Graph printing enhancement

### DIFF
--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -452,12 +452,12 @@ class Graph(object):
     def node_repr(self):
         """Format to visualize the Graph."""
         canvas_ = canvas.Canvas()
-        x = 0
+        x = 2
 
         evaluation_matrix = self.evaluation_matrix
 
         for row in evaluation_matrix:
-            y = 0
+            y = 2
             x_diff = 0
             for node in row:
                 item_ = item.Item(str(node), [x, y])
@@ -481,6 +481,13 @@ class Graph(object):
                                dnode.all_inputs()).values()).index(
                         connection)]
                     canvas_.add_item(item.Line(start, end), 0)
+
+        # The graph
+        canvas_.add_item(item.Line((0, 0), (0, canvas_.bbox[3])))
+        canvas_.add_item(item.Line((1, 0), (canvas_.bbox[2], 0)))
+        canvas_.add_item(item.Line((canvas_.bbox[2], 0), (canvas_.bbox[2], canvas_.bbox[3] - 1)))
+        canvas_.add_item(item.Line((1, canvas_.bbox[3] - 1), (canvas_.bbox[2] - 2, canvas_.bbox[3] - 1)))
+
         return canvas_.render()
 
     def list_repr(self):

--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -452,12 +452,12 @@ class Graph(object):
     def node_repr(self):
         """Format to visualize the Graph."""
         canvas_ = canvas.Canvas()
-        x = 2
+        x = 0
 
         evaluation_matrix = self.evaluation_matrix
 
         for row in evaluation_matrix:
-            y = 2
+            y = 0
             x_diff = 0
             for node in row:
                 item_ = item.Item(str(node), [x, y])
@@ -467,6 +467,40 @@ class Graph(object):
                 y += item_.bbox[3] - item_.bbox[1]
                 canvas_.add_item(item_)
             x += x_diff
+
+        # Include the input groups if any have been set
+        y_off = 2
+        locked_items = []
+        if self.input_groups:
+            for input_group in self.input_groups.values():
+                y_off += 1
+                i = item.Item("o {0}".format(input_group.name), [0, y_off])
+                canvas_.add_item(i)
+                locked_items.append(i)
+                for p in input_group.plugs:
+                    y_off += 1
+                    i = item.Item("`-{0}.{1}".format(p.node.name, p.name), [2, y_off])
+                    canvas_.add_item(i)
+                    locked_items.append(i)
+
+        # Move all items down by Y
+        for i in canvas_.items:
+            if i not in locked_items:
+                i.position[0] += 2
+                i.position[1] += y_off + 1 + int(bool(self.input_groups))
+
+        canvas_.add_item(item.Rectangle(x, canvas_.bbox[3] + 1, [0, 0]), 0)
+
+        # Crop the name of the graph if it is too long
+        name = self.name
+        if len(name) > x - 2:
+            name = name[:x - 2]
+        canvas_.add_item(
+            item.Item("{name:^{x}}".format(name=name, x=x), [0, 1]), 0)
+        canvas_.add_item(item.Rectangle(x, 3, [0, 0]), 0)
+
+        if self.input_groups:
+            canvas_.add_item(item.Rectangle(x, y_off + 2, [0, 0]), 0)
 
         for node in self.all_nodes:
             for i, plug in enumerate(node._sort_plugs(node.all_outputs())):
@@ -482,18 +516,20 @@ class Graph(object):
                         connection)]
                     canvas_.add_item(item.Line(start, end), 0)
 
-        # The graph
-        canvas_.add_item(item.Line((0, 0), (0, canvas_.bbox[3])))
-        canvas_.add_item(item.Line((1, 0), (canvas_.bbox[2], 0)))
-        canvas_.add_item(item.Line((canvas_.bbox[2], 0), (canvas_.bbox[2], canvas_.bbox[3] - 1)))
-        canvas_.add_item(item.Line((1, canvas_.bbox[3] - 1), (canvas_.bbox[2] - 2, canvas_.bbox[3] - 1)))
-
         return canvas_.render()
 
     def list_repr(self):
         """List representation of the graph showing Nodes and connections."""
         pretty = []
         pretty.append(self.name)
+
+        if self.input_groups:
+            pretty.append("[Input Groups]")
+            for name in sorted(self.input_groups.keys()):
+                input_group = self.input_groups[name]
+                pretty.append(" [g] {0}:".format(name))
+                for p in input_group.plugs:
+                    pretty.append("  {0}.{1}".format(p.node.name, p.name))
         for node in self.evaluation_sequence:
             pretty.append(node.list_repr())
         return '\n '.join(pretty)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,16 +1,14 @@
 from __future__ import print_function
 
-import pytest
-
-import flowpipe.graph
 import time
 
+import flowpipe.graph
+import pytest
+from flowpipe.errors import CycleError
+from flowpipe.graph import (Graph, get_default_graph, reset_default_graph,
+                            set_default_graph)
 from flowpipe.node import INode, Node
 from flowpipe.plug import InputPlug, OutputPlug
-from flowpipe.graph import Graph
-from flowpipe.graph import reset_default_graph
-from flowpipe.graph import set_default_graph, get_default_graph
-from flowpipe.errors import CycleError
 
 
 @pytest.fixture
@@ -230,6 +228,10 @@ def test_string_representations_with_subgraphs(clear_default_graph):
     n1.outputs['out'] >> end.inputs['in1']['1']
     n2.outputs['out']['0'] >> end.inputs['in1']['2']
     n2.outputs['out']['0'] >> end.inputs['in2']
+
+    print('\n')
+    print(main)
+    return
 
     assert str(main) == '\
 +----main----+          +----sub1----+                  +--------sub2--------+\n\

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -8,7 +8,7 @@ from flowpipe.errors import CycleError
 from flowpipe.graph import (Graph, get_default_graph, reset_default_graph,
                             set_default_graph)
 from flowpipe.node import INode, Node
-from flowpipe.plug import InputPlug, OutputPlug
+from flowpipe.plug import InputPlug, InputPlugGroup, OutputPlug
 
 
 @pytest.fixture
@@ -171,23 +171,27 @@ def test_serialize_graph_to_pickle(clear_default_graph, branching_graph):
 def test_string_representations(clear_default_graph, branching_graph):
     """Print the Graph."""
     assert str(branching_graph) == '\
-+------------+          +------------+          +--------------------+\n\
-|   Start    |          |   Node1    |          |        End         |\n\
-|------------|          |------------|          |--------------------|\n\
-o in1<>      |     +--->o in1<>      |          % in1<>              |\n\
-o in2<>      |     |    o in2<>      |     +--->o  in1.1<>           |\n\
-|      out<> o-----+    |      out<> o-----+--->o  in1.2<>           |\n\
-|     out2<> o     |    |     out2<> o     |    o in2<>              |\n\
-+------------+     |    +------------+     |    |              out<> o\n\
-                   |    +------------+     |    |             out2<> o\n\
-                   |    |   Node2    |     |    +--------------------+\n\
-                   |    |------------|     |                          \n\
-                   +--->o in1<>      |     |                          \n\
-                        o in2<>      |     |                          \n\
-                        |      out<> o-----+                          \n\
-                        |     out2<> o                                \n\
-                        +------------+                                '
-
++------------------------------------------------------------------------+\n\
+|                               TestGraph                                |\n\
+|------------------------------------------------------------------------|\n\
+| +------------+          +------------+          +--------------------+ |\n\
+| |   Start    |          |   Node1    |          |        End         | |\n\
+| |------------|          |------------|          |--------------------| |\n\
+| o in1<>      |     +--->o in1<>      |          % in1<>              | |\n\
+| o in2<>      |     |    o in2<>      |     +--->o  in1.1<>           | |\n\
+| |      out<> o-----+    |      out<> o-----+--->o  in1.2<>           | |\n\
+| |     out2<> o     |    |     out2<> o     |    o in2<>              | |\n\
+| +------------+     |    +------------+     |    |              out<> o |\n\
+|                    |    +------------+     |    |             out2<> o |\n\
+|                    |    |   Node2    |     |    +--------------------+ |\n\
+|                    |    |------------|     |                           |\n\
+|                    +--->o in1<>      |     |                           |\n\
+|                         o in2<>      |     |                           |\n\
+|                         |      out<> o-----+                           |\n\
+|                         |     out2<> o                                 |\n\
+|                         +------------+                                 |\n\
++------------------------------------------------------------------------+\n\
+                                                                          '
     assert branching_graph.list_repr() == """TestGraph
  Start
   [i] in1: null
@@ -228,30 +232,30 @@ def test_string_representations_with_subgraphs(clear_default_graph):
     n1.outputs['out'] >> end.inputs['in1']['1']
     n2.outputs['out']['0'] >> end.inputs['in1']['2']
     n2.outputs['out']['0'] >> end.inputs['in2']
-
-    print('\n')
-    print(main)
-    return
-
     assert str(main) == '\
-+----main----+          +----sub1----+                  +--------sub2--------+\n\
-|   Start    |          |   Node1    |                  |        End         |\n\
-|------------|          |------------|                  |--------------------|\n\
-o in1<>      |     +--->o in1<>      |                  % in1<>              |\n\
-o in2<>      |     |    o in2<>      |         +------->o  in1.1<>           |\n\
-|      out<> o-----+    |      out<> o---------+   +--->o  in1.2<>           |\n\
-|     out2<> o     |    |     out2<> o             |--->o in2<>              |\n\
-+------------+     |    +------------+             |    |              out<> o\n\
-                   |    +--------sub1--------+     |    |             out2<> o\n\
-                   |    |       Node2        |     |    +--------------------+\n\
-                   |    |--------------------|     |                          \n\
-                   |    % in1<>              |     |                          \n\
-                   +--->o  in1.0<>           |     |                          \n\
-                        o in2<>              |     |                          \n\
-                        |              out<> %     |                          \n\
-                        |           out.0<>  o-----+                          \n\
-                        |             out2<> o                                \n\
-                        +--------------------+                                '
++--------------------------------------------------------------------------------+\n\
+|                                      main                                      |\n\
+|--------------------------------------------------------------------------------|\n\
+| +----main----+          +----sub1----+                  +--------sub2--------+ |\n\
+| |   Start    |          |   Node1    |                  |        End         | |\n\
+| |------------|          |------------|                  |--------------------| |\n\
+| o in1<>      |     +--->o in1<>      |                  % in1<>              | |\n\
+| o in2<>      |     |    o in2<>      |         +------->o  in1.1<>           | |\n\
+| |      out<> o-----+    |      out<> o---------+   +--->o  in1.2<>           | |\n\
+| |     out2<> o     |    |     out2<> o             |--->o in2<>              | |\n\
+| +------------+     |    +------------+             |    |              out<> o |\n\
+|                    |    +--------sub1--------+     |    |             out2<> o |\n\
+|                    |    |       Node2        |     |    +--------------------+ |\n\
+|                    |    |--------------------|     |                           |\n\
+|                    |    % in1<>              |     |                           |\n\
+|                    +--->o  in1.0<>           |     |                           |\n\
+|                         o in2<>              |     |                           |\n\
+|                         |              out<> %     |                           |\n\
+|                         |           out.0<>  o-----+                           |\n\
+|                         |             out2<> o                                 |\n\
+|                         +--------------------+                                 |\n\
++--------------------------------------------------------------------------------+\n\
+                                                                                  '
 
 
 def test_nodes_can_be_added_to_graph(clear_default_graph):
@@ -281,6 +285,79 @@ def test_nodes_can_be_deleted(clear_default_graph, branching_graph):
 
     branching_graph.delete_node(branching_graph["End"])
     assert 0 == len(branching_graph.nodes)
+
+
+def test_string_representation_with_inputpluggroups(branching_graph):
+    InputPlugGroup("in1", branching_graph, [
+        branching_graph["Node1"].inputs["in1"],
+        branching_graph["Node2"].inputs["in1"],
+    ])
+    InputPlugGroup("in2", branching_graph, [
+        branching_graph["Node1"].inputs["in2"],
+        branching_graph["Node2"].inputs["in2"],
+    ])
+    assert str(branching_graph) == """\
++------------------------------------------------------------------------+
+|                               TestGraph                                |
+|------------------------------------------------------------------------|
+o in1                                                                    |
+| `-Node1.in1                                                            |
+| `-Node2.in1                                                            |
+o in2                                                                    |
+| `-Node1.in2                                                            |
+| `-Node2.in2                                                            |
+|------------------------------------------------------------------------|
+| +------------+          +------------+          +--------------------+ |
+| |   Start    |          |   Node1    |          |        End         | |
+| |------------|          |------------|          |--------------------| |
+| o in1<>      |     +--->o in1<>      |          % in1<>              | |
+| o in2<>      |     |    o in2<>      |     +--->o  in1.1<>           | |
+| |      out<> o-----+    |      out<> o-----+--->o  in1.2<>           | |
+| |     out2<> o     |    |     out2<> o     |    o in2<>              | |
+| +------------+     |    +------------+     |    |              out<> o |
+|                    |    +------------+     |    |             out2<> o |
+|                    |    |   Node2    |     |    +--------------------+ |
+|                    |    |------------|     |                           |
+|                    +--->o in1<>      |     |                           |
+|                         o in2<>      |     |                           |
+|                         |      out<> o-----+                           |
+|                         |     out2<> o                                 |
+|                         +------------+                                 |
++------------------------------------------------------------------------+
+                                                                          """
+
+    print(branching_graph.list_repr())
+    # return
+    assert branching_graph.list_repr() == """TestGraph
+ [Input Groups]
+  [g] in1:
+   Node1.in1
+   Node2.in1
+  [g] in2:
+   Node1.in2
+   Node2.in2
+ Start
+  [i] in1: null
+  [i] in2: null
+  [o] out >> Node1.in1, Node2.in1
+  [o] out2: null
+ Node1
+  [i] in1 << Start.out
+  [i] in2: null
+  [o] out >> End.in1.1
+  [o] out2: null
+ Node2
+  [i] in1 << Start.out
+  [i] in2: null
+  [o] out >> End.in1.2
+  [o] out2: null
+ End
+  [i] in1
+   [i] in1.1 << Node1.out
+   [i] in1.2 << Node2.out
+  [i] in2: null
+  [o] out: null
+  [o] out2: null"""
 
 
 def test_nested_graphs_expand_sub_graphs(clear_default_graph):
@@ -480,7 +557,6 @@ def test_cycle_error_when_node_connects_to_itself():
     """
     graph = Graph()
     N1 = FunctionNodeForTesting(name="N1", graph=graph)
-    print(graph)
     with pytest.raises(CycleError):
         N1.outputs["out"] >> N1.inputs["in_"]
 


### PR DESCRIPTION
Related to #142
Graphs are now printed with a frame and a header and contain the input plug groups (if they have any):

```python
+------------------------------------------------------------------------+
|                               TestGraph                                |
|------------------------------------------------------------------------|
o in1                                                                    |
| `-Node1.in1                                                            |
| `-Node2.in1                                                            |
o in2                                                                    |
| `-Node1.in2                                                            |
| `-Node2.in2                                                            |
|------------------------------------------------------------------------|
| +------------+          +------------+          +--------------------+ |
| |   Start    |          |   Node1    |          |        End         | |
| |------------|          |------------|          |--------------------| |
| o in1<>      |     +--->o in1<>      |          % in1<>              | |
| o in2<>      |     |    o in2<>      |     +--->o  in1.1<>           | |
| |      out<> o-----+    |      out<> o-----+--->o  in1.2<>           | |
| |     out2<> o     |    |     out2<> o     |    o in2<>              | |
| +------------+     |    +------------+     |    |              out<> o |
|                    |    +------------+     |    |             out2<> o |
|                    |    |   Node2    |     |    +--------------------+ |
|                    |    |------------|     |                           |
|                    +--->o in1<>      |     |                           |
|                         o in2<>      |     |                           |
|                         |      out<> o-----+                           |
|                         |     out2<> o                                 |
|                         +------------+                                 |
+------------------------------------------------------------------------+
```