### PR TITLE
Added an event to be run in nodes when the compute method raises an e…

### DIFF
--- a/flowpipe/node.py
+++ b/flowpipe/node.py
@@ -38,7 +38,8 @@ class INode(object):
 
     EVENT_TYPES = ['evaluation-omitted',
                    'evaluation-started',
-                   'evaluation-finished']
+                   'evaluation-finished',
+                   'evaluation-exception']
 
     def __init__(self, name=None, identifier=None, metadata=None,
                  graph='default'):
@@ -136,7 +137,11 @@ class INode(object):
 
         # Compute and redirect the output to the output plugs
         start_time = time.time()
-        outputs = self.compute(**inputs) or dict()
+        try:
+            outputs = self.compute(**inputs) or dict()
+        except Exception:
+            self.EVENTS['evaluation-exception'].emit(self)
+            raise
         eval_time = time.time() - start_time
 
         self.stats = {

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -801,3 +801,23 @@ def test_rshift_into_input_plug_group(clear_default_graph):
 
     n1 >> ig
     assert n2.inputs["marker"] in n1.outputs["marker"].connections
+
+
+def test_exception_event(clear_default_graph):
+    """Test the proper handling of exceptions in nodes."""
+    g = Graph()
+
+    def has_been_executed(n):
+        n.event_happened = True
+
+    @Node()
+    def ErrorNode():
+        raise Exception
+
+    en = ErrorNode(graph=g)
+    en.EVENTS['evaluation-exception'].register(has_been_executed)
+
+    with pytest.raises(Exception):
+        g.evaluate()
+
+    assert en.event_happened


### PR DESCRIPTION
…xception.

We're adding tracing to our flow now. To track node executions, we start and end trace spans on the `evaluation-started` and `evaluation-finished` events. However, exceptions raised in node execution would leave open spans.

To amend that in a non-breaking manner, I added a new event, `evaluation-exception` that gets triggered on exceptions, before raising the original Exception.

In a second step, it would be great to hand the actual exception to that event. However, this is an interface change to the current implementation of events.