### PR TITLE
Fixes Error with node representation when input is dictionary

### DIFF
--- a/flowpipe/node.py
+++ b/flowpipe/node.py
@@ -14,7 +14,7 @@ from abc import ABCMeta, abstractmethod
 from .event import Event
 from .graph import get_default_graph
 from .plug import InputPlug, InputPlugGroup, OutputPlug, SubOutputPlug, SubPlug
-from .utilities import NodeEncoder, deserialize_node, import_class
+from .utilities import NodeEncoder, deserialize_node, import_class, sanitize_string_input
 
 log = logging.getLogger(__name__)
 
@@ -420,16 +420,19 @@ class INode:
                 pretty += offset
             symbol = "%" if in_plug.sub_plugs else "o"
             dist = " " if isinstance(in_plug, SubPlug) else ""
-            plug = f"{symbol} {dist}{input_}{_short_value(in_plug)}".format()
+            value_in_plug = _short_value(in_plug)
+            value_in_plug = sanitize_string_input(value_in_plug)
+            plug = f"{symbol} {dist}{input_}{value_in_plug}".format()
             pretty += f"{plug:{width + 1}}|"
 
         # Outputs
         for output in sorted(all_outputs.keys()):
             out_plug = all_outputs[output]
             dist = 2 if isinstance(out_plug, SubPlug) else 1
-            value = _short_value(out_plug)
+            value_out_plug = _short_value(out_plug)
+            value_out_plug = sanitize_string_input(value_out_plug)
             symbol = "%" if out_plug.sub_plugs else "o"
-            pretty += f"\n{offset}|{output:>{width - dist - len(value)}}{value}{dist * ' '}{symbol}"
+            pretty += f"\n{offset}|{output:>{width - dist - len(value_out_plug)}}{value_out_plug}{dist * ' '}{symbol}"
             if all_outputs[output].connections:
                 pretty += "---"
 

--- a/flowpipe/node.py
+++ b/flowpipe/node.py
@@ -14,7 +14,12 @@ from abc import ABCMeta, abstractmethod
 from .event import Event
 from .graph import get_default_graph
 from .plug import InputPlug, InputPlugGroup, OutputPlug, SubOutputPlug, SubPlug
-from .utilities import NodeEncoder, deserialize_node, import_class, sanitize_string_input
+from .utilities import (
+    NodeEncoder,
+    deserialize_node,
+    import_class,
+    sanitize_string_input,
+)
 
 log = logging.getLogger(__name__)
 

--- a/flowpipe/utilities.py
+++ b/flowpipe/utilities.py
@@ -136,3 +136,13 @@ def get_hash(obj, hash_func=lambda x: sha256(x).hexdigest()):
                 return None
         else:
             return None  # pragma: no cover
+
+def sanitize_string_input(input_str):
+    """
+    Escapes dangerous "{" for f strings. Call it before running format
+    Args:
+        input_str (str): string to be sanitized
+    Returns:
+        (str): Sanitized string
+    """
+    return input_str.replace("{","{{").replace("}","}}")

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -34,9 +34,11 @@ class SquareNode(INode):
 def SquareFunctionNode(in1, compound_in):
     return {"out": in1**2}
 
+
 @Node(outputs=["out"])
 def DictOutNode(in1):
-    return {"out": {"result":True}}
+    return {"out": {"result": True}}
+
 
 class SimpleNode(INode):
     """A simple node."""
@@ -257,24 +259,28 @@ Node2
   [o] out: "value longer than max"'''
     )
 
+
 def test_string_representation_dict(clear_default_graph):
     """
     Given two connected nodes where one returns a dict as an output, print the node with the in connection
     Should return a safe truncated string representation
     """
-    
-    node_a= DictOutNode(name="NodeA")
+
+    node_a = DictOutNode(name="NodeA")
     node_b = DictOutNode(name="NodeB")
     node_a.outputs["out"] >> node_b.inputs["in1"]
     node_a.evaluate()
-    assert str(node_b) == """\
+    assert (
+        str(node_b)
+        == """\
    +--------------------+
    |       NodeB        |
    |--------------------|
 -->o in1<{'resul...>    |
    |              out<> o
    +--------------------+"""
-    
+    )
+
 
 def test_node_has_unique_identifier(clear_default_graph):
     """A Node gets a unique identifiers assigned."""

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -34,6 +34,9 @@ class SquareNode(INode):
 def SquareFunctionNode(in1, compound_in):
     return {"out": in1**2}
 
+@Node(outputs=["out"])
+def DictOutNode(in1):
+    return {"out": {"result":True}}
 
 class SimpleNode(INode):
     """A simple node."""
@@ -254,6 +257,24 @@ Node2
   [o] out: "value longer than max"'''
     )
 
+def test_string_representation_dict(clear_default_graph):
+    """
+    Given two connected nodes where one returns a dict as an output, print the node with the in connection
+    Should return a safe truncated string representation
+    """
+    
+    node_a= DictOutNode(name="NodeA")
+    node_b = DictOutNode(name="NodeB")
+    node_a.outputs["out"] >> node_b.inputs["in1"]
+    node_a.evaluate()
+    assert str(node_b) == """\
+   +--------------------+
+   |       NodeB        |
+   |--------------------|
+-->o in1<{'resul...>    |
+   |              out<> o
+   +--------------------+"""
+    
 
 def test_node_has_unique_identifier(clear_default_graph):
     """A Node gets a unique identifiers assigned."""

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -82,3 +82,14 @@ def test_get_hash():
 
     x = WeirdObject()
     assert util.get_hash(x) is None
+
+
+def test_sanitize_string():
+    """
+    Given a string with curly braces inside
+    Return a string with the curly braces escaped
+    """
+    test_string = "This is a {test} string"
+    expected_string = "This is a {{test}} string"
+    sanitized_string = util.sanitize_string_input(test_string)
+    assert sanitized_string == expected_string


### PR DESCRIPTION
## Problem

Fixes error we encountered with printing a node. If a node receives a precomputed input that is a string, and you try to print the node, it errors with the error

```python
ValueError: expected '}' before end of string
```

The reason for that is that it tires to f-print a truncated string representation of a dictionary, which includes a curly brace.
Curly braces, however, have special meaning in f-string. It then errors out since the string input has not been sanitized
## How to reproduce

Check my added unit test. If you comment out flowpipe/node.py:429, you should get the error. 
```python
value_in_plug = sanitize_string_input(value_in_plug)
```

## Solution

I added string sanitation before passing the string to the f-string method
