### PR TITLE
Fix pylinter issues

### DIFF
--- a/flowpipe/graph.py
+++ b/flowpipe/graph.py
@@ -253,6 +253,7 @@ class Graph:
 
     def evaluate(
         self,
+        *,
         mode="linear",
         skip_clean=False,
         submission_delay=0.1,

--- a/flowpipe/node.py
+++ b/flowpipe/node.py
@@ -540,6 +540,7 @@ class FunctionNode(INode):
 
     def __init__(
         self,
+        *,
         func=None,
         outputs=None,
         name=None,
@@ -695,6 +696,6 @@ def Node(*args, **kwargs):  # pylint: disable=invalid-name
     cls = kwargs.pop("cls", FunctionNode)
 
     def node(func):
-        return cls(func, *args, **kwargs)
+        return cls(func=func, *args, **kwargs)
 
     return node

--- a/flowpipe/plug.py
+++ b/flowpipe/plug.py
@@ -1,15 +1,10 @@
 """Plugs are ins and outs for Nodes through which they exchange data."""
 from __future__ import print_function
 
-import sys
 import warnings
 from abc import abstractmethod
 
 from .utilities import get_hash
-
-if sys.version_info.major > 2:  # pragma: no cover
-    basestring = str  # pylint: disable=invalid-name
-
 
 class IPlug:
     """The interface for the plugs.
@@ -197,7 +192,7 @@ class OutputPlug(IPlug):
         Args:
             key (str): The name of the sub plug
         """
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             raise TypeError(
                 "Only strings are allowed as sub-plug keys! "
                 "This is due to the fact that JSON serialization only allows "
@@ -267,7 +262,7 @@ class InputPlug(IPlug):
         Args:
             key (str): The name of the sub plug
         """
-        if not isinstance(key, basestring):
+        if not isinstance(key, str):
             raise TypeError(
                 "Only strings are allowed as sub-plug keys! "
                 "This is due to the fact that JSON serialization only allows "
@@ -440,8 +435,7 @@ class InputPlugGroup:
 
     def __iter__(self):
         """Convenience to iterate over the plugs in this group."""
-        for plug in self.plugs:
-            yield plug
+        yield from self.plugs
 
     def __rshift__(self, other):
         """Syntactic sugar for the connect() method."""


### PR DESCRIPTION
This PR is addressing the Pylinter issues. 

* It fixes the yield in a loop to a yield from
* it fixes the ist R0917 Too many positional arguments by forcing these functions to be keyword only
* replaces basestring with str and drop the support for python2 in this case