### PR TITLE
update git actions to use auto versioning based on release tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,10 @@ jobs:
           python -m pip install --upgrade poetry wheel
       - name: Install dependencies
         run: |
+          poetry self add poetry-dynamic-versioning
           poetry install
+      - name: Show version (debug)
+        run: poetry version
       - name: Publish
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ disable = [
 
 [tool.poetry]
 name = "Flowpipe"
-version = "1.0.4"
+version = "0.0.0"
 description = "A lightweight framework for flow-based programming in python."
 authors = ["Paul Schweizer <paulschweizer@gmx.net>"]
 license = "MIT"
@@ -32,11 +32,18 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 
 [tool.poetry.dependencies]
 python = ">=3.9"
 ascii-canvas = ">=2.0.0"
+
+[tool.poetry.plugins."poetry.plugin"]
+"dynamic-versioning" = "poetry_dynamic_versioning.plugin"
+
+[tool.poetry-dynamic-versioning]
+enable = true
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.11.0"


### PR DESCRIPTION
This PR updates the config and poetry config to use the versioning provided by the release tag (v.x.x.x) for pypi publish